### PR TITLE
Feat: タスクの完了処理を実装

### DIFF
--- a/app/controllers/completions_controller.rb
+++ b/app/controllers/completions_controller.rb
@@ -1,0 +1,12 @@
+class CompletionsController < ApplicationController
+  def update
+    task = Task.find(params[:task_id])
+    task.update!(task_params)
+    redirect_to root_path
+  end
+
+  private
+  def task_params
+    params.require(:task).permit(:completed)
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,8 @@ class TasksController < ApplicationController
   before_action :set_task, only: [ :edit, :update ]
 
   def index
-    @tasks = Task.all.order(:deadline).order(:created_at)
+    @uncompleted_tasks = Task.uncompleted.order(:deadline).order(:created_at)
+    @completed_tasks = Task.completed.order(updated_at: :desc).order(:created_at)
     @task = Task.new
   end
 

--- a/app/controllers/whole_completions_controller.rb
+++ b/app/controllers/whole_completions_controller.rb
@@ -1,0 +1,13 @@
+class WholeCompletionsController < ApplicationController
+  def create
+    uncompleted_tasks = Task.uncompleted
+    uncompleted_tasks.update_all(completed: true)
+    redirect_to root_path
+  end
+
+  def destroy
+    completed_tasks = Task.completed
+    completed_tasks.update_all(completed: false)
+    redirect_to root_path
+  end
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -3,7 +3,7 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Configure Stimulus development experience
-application.debug = false
+application.debug = true
 window.Stimulus   = application
 
 export { application }

--- a/app/javascript/controllers/task_controller.js
+++ b/app/javascript/controllers/task_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="task"
+export default class extends Controller {
+
+  // 完了チェックが切り替わったらフォームをsubmit
+  completionSubmit() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,4 +23,8 @@ class Task < ApplicationRecord
       errors.add(:base, '完了したタスクは編集できません')
     end
   end
+
+  # スコープ
+  scope :completed, -> { where(completed: true) }
+  scope :uncompleted, -> { where(completed: false) }
 end

--- a/app/views/tasks/_card.html.haml
+++ b/app/views/tasks/_card.html.haml
@@ -1,0 +1,6 @@
+= form_with(model: task, url: task_completion_path(task), method: 'put', local: true) do |f|
+  %div= f.check_box :completed
+  %div= f.submit '更新'
+= link_to edit_task_path(task), class: 'task_content' do
+  %div= task.title
+  %div= task.display_deadline

--- a/app/views/tasks/_card.html.haml
+++ b/app/views/tasks/_card.html.haml
@@ -1,6 +1,6 @@
-= form_with(model: task, url: task_completion_path(task), method: 'put', local: true) do |f|
-  %div= f.check_box :completed
-  %div= f.submit '更新'
-= link_to edit_task_path(task), class: 'task_content' do
+= form_with(model: task, url: task_completion_path(task), method: 'put', local: true, data: { controller: 'task' }) do |f|
+  %div= f.check_box :completed, data: { action: 'change->task#completionSubmit' }
+
+= link_to edit_task_path(task), data: { turbo_frame: '_top' }, class: 'task_content' do
   %div= task.title
   %div= task.display_deadline

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,5 +1,11 @@
 .container
   %h1 TODO
+ 
+  %div 一括切り替え
+  %ul
+    %li= link_to 'すべて完了にする', whole_completion_path, data: { turbo_method: :post, turbo_confirm: 'すべてのタスクを完了しますか？' }
+    %li= link_to 'すべて未完了にする', whole_completion_path, data: { turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }
+
   %section.tasks
     %ul.uncompleted_task_list
       - @uncompleted_tasks.each do |task|

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -3,8 +3,11 @@
   %section.tasks
     %ul.task_list
       - @tasks.each do |task|
-        = link_to edit_task_path(task) do
-          %li
+        %li
+          = form_with(model: task, url: task_completion_path(task), method: 'put', local: true) do |f|
+            %div= f.check_box :completed
+            %div= f.submit '更新'
+          = link_to edit_task_path(task), class: 'task_content' do
             %div= task.title
             %div= task.display_deadline
 

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -3,8 +3,8 @@
  
   %div 一括切り替え
   %ul
-    %li= link_to 'すべて完了にする', whole_completion_path, data: { turbo_method: :post, turbo_confirm: 'すべてのタスクを完了しますか？' }
-    %li= link_to 'すべて未完了にする', whole_completion_path, data: { turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }
+    %li= link_to 'すべて完了にする', whole_completion_path, data: { turbo_frame: 'tasks-list', turbo_method: :post, turbo_confirm: 'すべてのタスクを完了しますか？' }
+    %li= link_to 'すべて未完了にする', whole_completion_path, data: { turbo_frame: 'tasks-list', turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }
 
   %section.tasks
     = turbo_frame_tag 'tasks-list' do

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -7,16 +7,17 @@
     %li= link_to 'すべて未完了にする', whole_completion_path, data: { turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }
 
   %section.tasks
-    %ul.uncompleted_task_list
-      - @uncompleted_tasks.each do |task|
-        %li
-          = render 'card', task: task
+    = turbo_frame_tag 'tasks-list' do
+      %ul.uncompleted_task_list
+        - @uncompleted_tasks.each do |task|
+          %li
+            = render 'card', task: task
 
-    %div 完了済み
-    %ul.completed_task_list
-      - @completed_tasks.each do |task|
-        %li
-          = render 'card', task: task
+      %div 完了済み
+      %ul.completed_task_list
+        - @completed_tasks.each do |task|
+          %li
+            = render 'card', task: task
 
     = form_with(model: @task, local: true) do |f|
       %div= f.label :title, '＋'

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,15 +1,16 @@
 .container
   %h1 TODO
   %section.tasks
-    %ul.task_list
-      - @tasks.each do |task|
+    %ul.uncompleted_task_list
+      - @uncompleted_tasks.each do |task|
         %li
-          = form_with(model: task, url: task_completion_path(task), method: 'put', local: true) do |f|
-            %div= f.check_box :completed
-            %div= f.submit '更新'
-          = link_to edit_task_path(task), class: 'task_content' do
-            %div= task.title
-            %div= task.display_deadline
+          = render 'card', task: task
+
+    %div 完了済み
+    %ul.completed_task_list
+      - @completed_tasks.each do |task|
+        %li
+          = render 'card', task: task
 
     = form_with(model: @task, local: true) do |f|
       %div= f.label :title, '＋'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'tasks#index'
-  resources :tasks, only: [ :create, :edit, :update, :destroy ]
+  resources :tasks, only: [ :create, :edit, :update, :destroy ] do
+    resource :completion, only: [ :update ]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'tasks#index'
+  scope :tasks do
+    resource :whole_completion, only: [ :create, :destroy ]
+  end
   resources :tasks, only: [ :create, :edit, :update, :destroy ] do
     resource :completion, only: [ :update ]
   end


### PR DESCRIPTION
## 実装内容
- タスクの完了処理を実装
  - 個別切り替え
  - 一括切り替え
  - 処理の非同期化（Stimulus, Turbo Frames）
 
## 関連issue/PR
- close #7 

## その他
- タスク一覧を、未完了・完了に分けて表示するようにした（未完了：期限順 / 完了：更新順）