### PR TITLE
Fix: タスク一覧の画面の切り替えを修正

### DIFF
--- a/app/controllers/whole_completions_controller.rb
+++ b/app/controllers/whole_completions_controller.rb
@@ -1,13 +1,15 @@
 class WholeCompletionsController < ApplicationController
   def create
+    type = params[:type] if params[:type].present?
     uncompleted_tasks = Task.uncompleted
     uncompleted_tasks.update_all(completed: true)
-    redirect_to root_path
+    redirect_to root_path(type: type)
   end
 
   def destroy
+    type = params[:type] if params[:type].present?
     completed_tasks = Task.completed
     completed_tasks.update_all(completed: false)
-    redirect_to root_path
+    redirect_to root_path(type: type)
   end
 end

--- a/app/views/tasks/_filter.html.haml
+++ b/app/views/tasks/_filter.html.haml
@@ -1,8 +1,8 @@
 #filter.col-auto
   %ul.filter_list
     %li.filter_item{ class: "#{add_active_class(type, nil)}" }
-      = link_to 'すべて', root_path, data: { turbo_stream: true }
+      = link_to 'すべて', root_path
     %li.filter_item{ class: "#{add_active_class(type, 'uncompleted')}" }
-      = link_to '未完了', root_path(type: 'uncompleted'), data: { turbo_stream: true }
+      = link_to '未完了', root_path(type: 'uncompleted')
     %li.filter_item{ class: "#{add_active_class(type, 'completed')}" }
-      = link_to '完了', root_path(type: 'completed'), data: { turbo_stream: true }
+      = link_to '完了', root_path(type: 'completed')

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -8,8 +8,8 @@
       %button#dropdownMenuButton1.btn.dropdown-toggle.bulk_action_btn{ type: "button", data: { bs_toggle: "dropdown" }, aria: { expanded: "false" } }
         一括切り替え
       %ul.dropdown-menu{ aria: { labelledby: "dropdownMenuButton1" } }
-        %li= link_to 'すべて完了にする', whole_completion_path, data: { turbo_method: :post, turbo_confirm: 'すべてのタスクを完了しますか？' }, class: 'dropdown-item'
-        %li= link_to 'すべて未完了にする', whole_completion_path, data: { turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }, class: 'dropdown-item'
+        %li= link_to 'すべて完了にする', whole_completion_path(type: @type), data: { turbo_method: :post, turbo_confirm: 'すべてのタスクを完了しますか？' }, class: 'dropdown-item'
+        %li= link_to 'すべて未完了にする', whole_completion_path(type: @type), data: { turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }, class: 'dropdown-item'
 
   %section.tasks
     .container.tasks_list_container

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,17 +1,17 @@
 %h1 TODO
 
-.row.index_action
-  = render 'filter', type: @type
+= turbo_frame_tag 'tasks-index' do
+  .row.index_action
+    = render 'filter', type: @type
 
-  .col-auto.dropdown
-    %button#dropdownMenuButton1.btn.dropdown-toggle.bulk_action_btn{ type: "button", data: { bs_toggle: "dropdown" }, aria: { expanded: "false" } }
-      一括切り替え
-    %ul.dropdown-menu{ aria: { labelledby: "dropdownMenuButton1" } }
-      %li= link_to 'すべて完了にする', whole_completion_path, data: { turbo_frame: 'tasks', turbo_method: :post, turbo_confirm: 'すべてのタスクを完了しますか？' }, class: 'dropdown-item'
-      %li= link_to 'すべて未完了にする', whole_completion_path, data: { turbo_frame: 'tasks', turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }, class: 'dropdown-item'
+    .col-auto.dropdown
+      %button#dropdownMenuButton1.btn.dropdown-toggle.bulk_action_btn{ type: "button", data: { bs_toggle: "dropdown" }, aria: { expanded: "false" } }
+        一括切り替え
+      %ul.dropdown-menu{ aria: { labelledby: "dropdownMenuButton1" } }
+        %li= link_to 'すべて完了にする', whole_completion_path, data: { turbo_method: :post, turbo_confirm: 'すべてのタスクを完了しますか？' }, class: 'dropdown-item'
+        %li= link_to 'すべて未完了にする', whole_completion_path, data: { turbo_method: :delete, turbo_confirm: 'すべてのタスクを未完了にしますか？' }, class: 'dropdown-item'
 
-%section.tasks
-  = turbo_frame_tag 'tasks' do
+  %section.tasks
     .container.tasks_list_container
       = render 'tasks_list', type: @type, uncompleted_tasks: @uncompleted_tasks, completed_tasks: @completed_tasks
 

--- a/app/views/tasks/index.turbo_stream.haml
+++ b/app/views/tasks/index.turbo_stream.haml
@@ -1,5 +1,0 @@
-= turbo_stream.replace 'filter' do 
-  = render 'filter', type: @type
-
-= turbo_stream.replace 'tasks_list' do
-  = render 'tasks_list', type: @type, uncompleted_tasks: @uncompleted_tasks, completed_tasks: @completed_tasks


### PR DESCRIPTION
## 実装内容
- タスク一覧の画面の切り替えを修正
  - フィルター変更時の画面切り替えを変更（turbo stream で部分変更 → turbo frame 一括で変更）
  - 完了状態の一括変更時、フィルターを維持するよう修正
 
**turbo frame 一括で変更にする理由：**
※index.html.haml 内の各所の @type（今のフィルターの種類）を、画面切り替え時に反映させたいから
