### PR TITLE
Refactor: コントローラー内の記述のリファクタリング

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  before_action :set_filter_type
+
+  def set_filter_type
+    @type = params[:type] if params[:type].present?
+  end
 end

--- a/app/controllers/completed_alls_controller.rb
+++ b/app/controllers/completed_alls_controller.rb
@@ -1,8 +1,7 @@
 class CompletedAllsController < ApplicationController
   def destroy
-    type = params[:type] if params[:type].present?
     completed_tasks = Task.completed
     completed_tasks.destroy_all
-    redirect_to root_path(type: type)
+    redirect_to root_path(type: @type)
   end
 end

--- a/app/controllers/completed_alls_controller.rb
+++ b/app/controllers/completed_alls_controller.rb
@@ -1,7 +1,6 @@
 class CompletedAllsController < ApplicationController
   def destroy
-    completed_tasks = Task.completed
-    completed_tasks.destroy_all
+    Task.completed_all_destroy
     redirect_to root_path(type: @type)
   end
 end

--- a/app/controllers/completions_controller.rb
+++ b/app/controllers/completions_controller.rb
@@ -1,9 +1,8 @@
 class CompletionsController < ApplicationController
   def update
-    type = params[:type] if params[:type].present?
     task = Task.find(params[:task_id])
     task.update!(task_params)
-    redirect_to root_path(type: type)
+    redirect_to root_path(type: @type)
   end
 
   private

--- a/app/controllers/completions_controller.rb
+++ b/app/controllers/completions_controller.rb
@@ -1,12 +1,7 @@
 class CompletionsController < ApplicationController
   def update
     task = Task.find(params[:task_id])
-    task.update!(task_params)
+    task.update!(completed: params[:task][:completed])
     redirect_to root_path(type: @type)
-  end
-
-  private
-  def task_params
-    params.require(:task).permit(:completed)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,5 @@
 class TasksController < ApplicationController
   before_action :set_task, only: [ :edit, :update ]
-  before_action :set_filter_type
 
   def index
     set_tasks_for_list
@@ -41,10 +40,6 @@ class TasksController < ApplicationController
 
   def set_task
     @task = Task.find(params[:id])
-  end
-
-  def set_filter_type
-    @type = params[:type] if params[:type].present?
   end
 
   def set_tasks_for_list

--- a/app/controllers/whole_completions_controller.rb
+++ b/app/controllers/whole_completions_controller.rb
@@ -1,13 +1,11 @@
 class WholeCompletionsController < ApplicationController
   def create
-    uncompleted_tasks = Task.uncompleted
-    uncompleted_tasks.update_all(completed: true)
+    Task.change_whole_completion_to(true)
     redirect_to root_path(type: @type)
   end
 
   def destroy
-    completed_tasks = Task.completed
-    completed_tasks.update_all(completed: false)
+    Task.change_whole_completion_to(false)
     redirect_to root_path(type: @type)
   end
 end

--- a/app/controllers/whole_completions_controller.rb
+++ b/app/controllers/whole_completions_controller.rb
@@ -1,15 +1,13 @@
 class WholeCompletionsController < ApplicationController
   def create
-    type = params[:type] if params[:type].present?
     uncompleted_tasks = Task.uncompleted
     uncompleted_tasks.update_all(completed: true)
-    redirect_to root_path(type: type)
+    redirect_to root_path(type: @type)
   end
 
   def destroy
-    type = params[:type] if params[:type].present?
     completed_tasks = Task.completed
     completed_tasks.update_all(completed: false)
-    redirect_to root_path(type: type)
+    redirect_to root_path(type: @type)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -35,7 +35,7 @@ class Task < ApplicationRecord
     target_tasks = status ? uncompleted : completed
     target_tasks.update_all(completed: status)
   end
-  
+
   # 完了済みタスクの一括削除
   def self.completed_all_destroy
     completed.destroy_all

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -35,4 +35,9 @@ class Task < ApplicationRecord
     target_tasks = status ? uncompleted : completed
     target_tasks.update_all(completed: status)
   end
+  
+  # 完了済みタスクの一括削除
+  def self.completed_all_destroy
+    completed.destroy_all
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -27,4 +27,12 @@ class Task < ApplicationRecord
   # スコープ
   scope :completed, -> { where(completed: true) }
   scope :uncompleted, -> { where(completed: false) }
+
+  # メソッド
+
+  # 完了状態の一括切り替え
+  def self.change_whole_completion_to(status)
+    target_tasks = status ? uncompleted : completed
+    target_tasks.update_all(completed: status)
+  end
 end


### PR DESCRIPTION
## 実装内容
- コントローラー内の記述のリファクタリング

### 詳細
- フィルタータイプ取得処理を共通化
- 完了の一括切り替え処理を共通化
- 完了済みタスクの一括削除メソッドをモデルに移動
- 個別完了切り替え処理の記述を変更（StrongParameterを使用せず、paramsからcompletedを直接取得）